### PR TITLE
Use Cabal 1.22 for GHC 7.4.2 in build-matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
     - env: CABALVER=1.16 GHCVER=7.2.2 NOTEST=1
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,zlib1g-dev], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.4.2
+    - env: CABALVER=1.22 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,zlib1g-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.4.2,zlib1g-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,zlib1g-dev], sources: [hvr-ghc]}}


### PR DESCRIPTION
because Cabal-1.16's solver is not clever enough
