### PR TITLE
Implement `resumeIndexBuilder`

### DIFF
--- a/Codec/Archive/Tar/Index.hs
+++ b/Codec/Archive/Tar/Index.hs
@@ -28,6 +28,10 @@ module Codec.Archive.Tar.Index (
     -- @tar@ file is needed to 'build' the 'TarIndex', but thereafter you can
     -- 'lookup' paths in the @tar@ file, and then use 'hReadEntry' to
     -- seek to the right part of the file and read the entry.
+    --
+    -- An index cannot be used to lookup 'Directory' entries in a tar file;
+    -- instead, you will get 'TarDir' entry listing all the entries in the
+    -- directory.
 
     -- * Index type
     TarIndex,

--- a/Codec/Archive/Tar/Index/IntTrie.hs
+++ b/Codec/Archive/Tar/Index/IntTrie.hs
@@ -39,6 +39,9 @@ import Control.Applicative ((<$>), (<*>))
 
 -- | A compact mapping from sequences of small nats to nats.
 --
+-- NOTE: The tries in this module have values /only/ at the leaves (which
+-- correspond to files), they do not have values at the branch points (which
+-- correspond to directories).
 newtype IntTrie k v = IntTrie (A.UArray Word32 Word32)
     deriving (Eq, Show, Typeable)
 

--- a/test/Properties.hs
+++ b/test/Properties.hs
@@ -19,11 +19,13 @@ main =
         testProperty "unit 2"      IntTrie.test2,
         testProperty "unit 3"      IntTrie.test3,
         testProperty "lookups"     IntTrie.prop_lookup_mono,
-        testProperty "completions" IntTrie.prop_completions_mono
+        testProperty "completions" IntTrie.prop_completions_mono,
+        testProperty "toList"      IntTrie.prop_construct_toList
       ]
     , testGroup "index" [
         testProperty "lookup"      Index.prop_lookup
       , testProperty "valid"       Index.prop_valid
       , testProperty "matches tar" Index.prop_index_matches_tar
+      , testProperty "resume"      Index.prop_finalise_resume
       ]
     ]


### PR DESCRIPTION
This is intended as the left inverse to `finaliseIndex`:

```
resumeIndexBuilder . finaliseIndex ≈ id
```

(modulo ordering). This required the definition of a new function `toList` on tries, intended as the left inverse to `construct`:

```
toList . construct ≈ id
```

(again module ordering). Added QuickCheck definitions for both of these properties.

This is implemented as a first step towards https://github.com/well-typed/hackage-security/issues/22.
