### PR TITLE
Provide default value for 'old-time' flag

### DIFF
--- a/tar.cabal
+++ b/tar.cabal
@@ -26,6 +26,7 @@ source-repository head
   location: http://code.haskell.org/tar/
 
 flag old-time
+  default: False
 
 library
   build-depends: base == 4.*,


### PR DESCRIPTION
This helps stack build projects that rely on `tar` (otherwise it seems to pick `old-time: True` by default, thus requiring `directory < 1.2`). 
