### PR TITLE
Remove redundant `Enum` constraint on `finalise`

### DIFF
--- a/Codec/Archive/Tar/Index/IntTrie.hs
+++ b/Codec/Archive/Tar/Index/IntTrie.hs
@@ -362,7 +362,7 @@ inserts :: (Enum k, Enum v) => [([k], v)]
         -> IntTrieBuilder k v -> IntTrieBuilder k v
 inserts kvs t = foldl' (\t' (ks, v) -> insert ks v t') t kvs
 
-finalise :: (Enum k, Enum v) => IntTrieBuilder k v -> IntTrie k v
+finalise :: IntTrieBuilder k v -> IntTrie k v
 finalise trie =
     IntTrie $
       A.listArray (0, fromIntegral (flatTrieLength trie) - 1)


### PR DESCRIPTION
GHC 8.0 points out the constraint on `finalise` to be redundant, so
let's drop it. `tar` still compiles with GHCs back to 7.0.4.
