### PR TITLE
Qualify catch import to work with old Prelude

### DIFF
--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -32,7 +32,7 @@ import System.Directory
          ( setModificationTime )
 import Data.Time.Clock.POSIX
          ( posixSecondsToUTCTime )
-import Control.Exception as Exception
+import qualified Control.Exception as Exception
          ( catch )
 import System.IO.Error
          ( isPermissionError )


### PR DESCRIPTION
When compiling with very old versions of base (from like 5 years ago), `Prelude` contains a function `catch` that name-conflicts with this import. So, I propose qualifying the import.

(See the error here: https://travis-ci.org/kolmodin/binary/jobs/116156062#L409)

The other option would be to restrict the version of base so that we don't use a version of base that contains this old `catch` function. I'm not sure exactly when `catch` was removed from Prelude, but I can find out.
