### PR TITLE
Add offending path to TarBombError

### DIFF
--- a/Codec/Archive/Tar/Check.hs
+++ b/Codec/Archive/Tar/Check.hs
@@ -123,19 +123,19 @@ checkEntryTarbomb :: FilePath -> Entry -> Maybe TarBombError
 checkEntryTarbomb expectedTopDir entry =
   case FilePath.Native.splitDirectories (entryPath entry) of
     (topDir:_) | topDir == expectedTopDir -> Nothing
-    _ -> Just $ TarBombError expectedTopDir
+    _ -> Just $ TarBombError expectedTopDir (entryPath entry)
 
 -- | An error that occurs if a tar file is a \"tar bomb\" that would extract
 -- files outside of the intended directory.
-data TarBombError = TarBombError FilePath
+data TarBombError = TarBombError FilePath FilePath
                   deriving (Typeable)
 
 instance Exception TarBombError
 
 instance Show TarBombError where
-  show (TarBombError expectedTopDir)
-    = "File in tar archive is not in the expected directory " ++ show expectedTopDir
-
+  show (TarBombError expectedTopDir tarBombPath)
+    = "File in tar archive, " ++ show tarBombPath ++
+    ", is not in the expected directory " ++ show expectedTopDir
 
 --------------------------
 -- Portability


### PR DESCRIPTION
The tarbomb detection fails when decoding the tarball for `binary-0.6.4.0`: https://hackage.haskell.org/package/binary-0.6.4.0/binary-0.6.4.0.tar.gz

This improves the error to make it clearer that the underlying issue is #1 .  Now the error is

> File in tar archive, "pax_global_header", is not in the expected directory "binary-0.6.4.0"

instead of 

> File in tar archive is not in the expected directory "binary-0.6.4.0"
