### PR TITLE
Codec.Archive.Tar.Types: fix test failures on 32-bit arches

### DIFF
--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -562,7 +562,7 @@ instance Arbitrary Entry where
       arbitraryPermissions = fromIntegral <$> (arbitraryOctal 7 :: Gen Int)
 
       arbitraryEpochTime :: Gen EpochTime
-      arbitraryEpochTime = fromIntegral <$> (arbitraryOctal 11 :: Gen Int)
+      arbitraryEpochTime = fromIntegral <$> (arbitraryOctal 11 :: Gen Int64)
 
   shrink (Entry path content perms author time format) =
       [ Entry path' content' perms author' time' format 


### PR DESCRIPTION
Serialization code (putOct) assumes entryTime is never negative.
It is always true on platforms with Int = Int64 but not
on Int = Int32.

Patch fixes failure on i386-unknown-linux

 Linking dist/build/properties/properties ...
 tar tests
  write/read
    ustar format: FAIL
      **\* Failed! Exception: 'Numeric.showIntAtBase: applied to negative number -1' (after 8 tests and 5 shrinks):
      [Entry {entryTarPath = "bbbb", entryContent = NormalFile "" 0, entryPermissions = 0, entryOwnership = Ownership {ownerName = "", groupName = "", ownerId = 0, groupId = 0}, entryTime = -1, entryFormat = V7Format}]
      Use --quickcheck-replay '7 TFGenR 00003063E4EC9A63000000003B9ACA00000000000000E0C8000000003B9ACA00 0 255 8 0' to reproduce.

Signed-off-by: Sergei Trofimovich siarheit@google.com
