### PR TITLE
Fix for base >= 4.11 (SMP)

### DIFF
--- a/Codec/Archive/Tar/Index.hs
+++ b/Codec/Archive/Tar/Index.hs
@@ -96,8 +96,11 @@ import Codec.Archive.Tar.Index.IntTrie (IntTrie, IntTrieBuilder)
 
 import qualified System.FilePath.Posix as FilePath
 import Data.Monoid (Monoid(..))
-#if (MIN_VERSION_base(4,5,0))
+#if MIN_VERSION_base(4,5,0) && !(MIN_VERSION_base(4,9,0))
 import Data.Monoid ((<>))
+#endif
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Word
 import Data.Int

--- a/Codec/Archive/Tar/Index/IntTrie.hs
+++ b/Codec/Archive/Tar/Index/IntTrie.hs
@@ -44,8 +44,11 @@ import qualified Data.Bits as Bits
 import Data.Word (Word32)
 import Data.Bits
 import Data.Monoid (Monoid(..))
-#if (MIN_VERSION_base(4,5,0))
+#if MIN_VERSION_base(4,5,0) && !(MIN_VERSION_base(4,9,0))
 import Data.Monoid ((<>))
+#endif
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
 #endif
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Lazy   as LBS

--- a/Codec/Archive/Tar/Index/StringTable.hs
+++ b/Codec/Archive/Tar/Index/StringTable.hs
@@ -37,8 +37,11 @@ import Data.Word (Word32)
 import Data.Int  (Int32)
 import Data.Bits
 import Data.Monoid (Monoid(..))
-#if (MIN_VERSION_base(4,5,0))
+#if MIN_VERSION_base(4,5,0) && !(MIN_VERSION_base(4,9,0))
 import Data.Monoid ((<>))
+#endif
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
 #endif
 import Control.Exception (assert)
 

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -62,6 +62,9 @@ module Codec.Archive.Tar.Types (
 
 import Data.Int      (Int64)
 import Data.Monoid   (Monoid(..))
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
+#endif
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS.Char8
 import qualified Data.ByteString.Lazy  as LBS
@@ -534,6 +537,11 @@ mapEntries f =
 mapEntriesNoFail :: (Entry -> Entry) -> Entries e -> Entries e
 mapEntriesNoFail f =
   foldEntries (\entry -> Next (f entry)) Done Fail
+
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup (Entries e) where
+  (<>) = mappend
+#endif
 
 instance Monoid (Entries e) where
   mempty      = Done


### PR DESCRIPTION
This should make the `tar` package build correctly on all phases of the SMP transition.