### PR TITLE
Set Owner Permissions on extracted files

### DIFF
--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -122,6 +122,8 @@ setOwnerPermissions :: FilePath -> Permissions -> IO ()
 setOwnerPermissions path permissions =
   setPermissions path ownerPermissions
   where
+    -- | Info on Permission bits can be found here:
+    -- https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
     ownerPermissions =
       setOwnerReadable   (testBit permissions 8) $
       setOwnerWritable   (testBit permissions 7) $

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -25,19 +25,18 @@ import System.FilePath
 import qualified System.FilePath as FilePath.Native
          ( takeDirectory )
 import System.Directory
-         ( createDirectoryIfMissing, copyFile, setPermissions, emptyPermissions, readable, writable
-         , executable, searchable )
+         ( createDirectoryIfMissing, copyFile, setPermissions )
 import Control.Exception
          ( Exception, throwIO )
 import System.Directory
-         ( setModificationTime )
+         ( setModificationTime, emptyPermissions, setOwnerReadable, setOwnerWritable
+         , setOwnerExecutable, setOwnerSearchable )
 import Data.Time.Clock.POSIX
          ( posixSecondsToUTCTime )
 import Control.Exception as Exception
          ( catch )
 import System.IO.Error
          ( isPermissionError )
-
 
 -- | Create local files and directories based on the entries of a tar archive.
 --
@@ -121,7 +120,11 @@ setModTime path t =
 
 setOwnerPermissions :: FilePath -> Permissions -> IO ()
 setOwnerPermissions path permissions =
-  setPermissions path emptyPermissions
-    { readable   = testBit permissions 8
-    , writable   = testBit permissions 7
-    , executable = testBit permissions 6 }
+  setPermissions path ownerPermissions
+  where
+    ownerPermissions =
+      setOwnerReadable   (testBit permissions 8) $
+      setOwnerWritable   (testBit permissions 7) $
+      setOwnerExecutable (testBit permissions 6) $
+      setOwnerSearchable (testBit permissions 6) $
+      emptyPermissions


### PR DESCRIPTION
Fixes [Issue 25](https://github.com/haskell/tar/issues/25): Extracted executable files do not have the executable flag set.

I've used `setPermission` from `System.Directory` as this is a portable way to set the owner permissions and requires no extra dependencies.

Even before I made my changes, I cant get the property tests to pass and not sure whats broken there.