### PR TITLE
Bump the constraint on time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+dist-newstyle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - (cd "." && cabal sdist)
-  - mv "."/dist/tar-*.tar.gz ${DISTDIR}/
+  - (cd "." && cabal new-sdist)
+  - mv "."/dist-newstyle/sdist/tar-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: tar-*/*.cabal\\n' > cabal.project"

--- a/tar.cabal
+++ b/tar.cabal
@@ -47,7 +47,7 @@ library
   if flag(old-time)
     build-depends: directory < 1.2, old-time < 1.2
   else
-    build-depends: directory >= 1.2 && < 1.4, time < 1.9
+    build-depends: directory >= 1.2 && < 1.4, time < 1.10
 
   if flag(old-bytestring)
     build-depends: bytestring-builder >= 0.10.4.0.2 && < 0.11, bytestring == 0.9.*


### PR DESCRIPTION
Encounter this when trying to build `cabal-install` using `ghc` HEAD where `time` was bumped to `1.9.2`.

Also fix the Travis CI script.