### PR TITLE
Fix symlinks

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: ./
+        , htar

--- a/htar/htar.cabal
+++ b/htar/htar.cabal
@@ -30,7 +30,7 @@ executable htar
     directory  >= 1.0,
     filepath   >= 1.0,
     bytestring >= 0.9,
-    tar        == 0.4.* && >= 0.4.2,
+    tar        >= 0.4.2 && < 0.7,
     zlib       >= 0.4 && < 0.7,
     bzlib      >= 0.4 && < 0.7
 

--- a/tar.cabal
+++ b/tar.cabal
@@ -41,7 +41,7 @@ library
   build-depends: base       == 4.*,
                  filepath             < 1.5,
                  array                < 0.6,
-                 containers >= 0.2 && < 0.6,
+                 containers >= 0.2 && < 0.7,
                  deepseq    >= 1.1 && < 1.5
 
   if flag(old-time)

--- a/tar.cabal
+++ b/tar.cabal
@@ -91,8 +91,8 @@ test-suite properties
                  deepseq,
                  bytestring-handle,
                  QuickCheck       == 2.*,
-                 tasty            >= 0.10 && <0.12,
-                 tasty-quickcheck == 0.8.*
+                 tasty            >= 0.10 && <1.2,
+                 tasty-quickcheck >= 0.8 && <0.11
 
   if flag(old-time)
     build-depends: directory < 1.2, old-time


### PR DESCRIPTION
This fixes https://github.com/haskell/tar/issues/32

We no longer fail when a symlink points to `../../Makefile.gen` (for instance), provided that it does not go outside of the unpacking directory.

(This is dependent on https://github.com/haskell/tar/pull/41)