### PR TITLE
Add tarPathNameHasSuffix

### DIFF
--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -62,6 +62,7 @@ module Codec.Archive.Tar.Entry (
 
   -- * TarPath type
   TarPath,
+  tarPathNameHasSuffix,
   toTarPath,
   fromTarPath,
   fromTarPathToPosixPath,


### PR DESCRIPTION
In a tar archive with enough files, fully reconstructing a `FilePath` for every single entry to check if its filename makes it important can be very expensive. For my particular application in https://gitlab.com/edmundnoble/packdep-notify, it's 40% of the total time I spend reading from the tar archive in question. Instead of fully exposing the structure of `TarPath` or even providing a general predicate over the filename, I'm thinking we can provide `tarPathNameHasSuffix` (bikeshedding on the name, pretty please).