### PR TITLE
base 4.13 compatibility

### DIFF
--- a/Codec/Archive/Tar/Read.hs
+++ b/Codec/Archive/Tar/Read.hs
@@ -252,7 +252,9 @@ instance Monad (Partial e) where
     return        = pure
     Error m >>= _ = Error m
     Ok    x >>= k = k x
+#if !MIN_VERSION_base(4,13,0)
     fail          = error "fail @(Partial e)"
+#endif
 
 {-# SPECIALISE readOct :: BS.ByteString -> Maybe Int   #-}
 {-# SPECIALISE readOct :: BS.ByteString -> Maybe Int64 #-}


### PR DESCRIPTION
base 4.13 finally removes `fail` from `Monad`. This patch adjusts for that fact.