### PR TITLE
Add support for over-long filepaths via GNU extension and fix hardlinks

### DIFF
--- a/Codec/Archive/Tar/Check.hs
+++ b/Codec/Archive/Tar/Check.hs
@@ -16,6 +16,7 @@ module Codec.Archive.Tar.Check (
 
   -- * Security
   checkSecurity,
+  checkEntrySecurity,
   FileNameError(..),
 
   -- * Tarbombs

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar.Entry
@@ -49,6 +50,7 @@ module Codec.Archive.Tar.Entry (
   simpleEntry,
   fileEntry,
   directoryEntry,
+  longLinkEntry,
 
   -- * Standard file permissions
   -- | For maximum portability when constructing archives use only these file
@@ -60,6 +62,9 @@ module Codec.Archive.Tar.Entry (
   -- * Constructing entries from disk files
   packFileEntry,
   packDirectoryEntry,
+#if MIN_VERSION_directory(1,3,1)
+  packSymlinkEntry,
+#endif
   getDirectoryContentsRecursive,
 
   -- * TarPath type

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -42,6 +42,8 @@ module Codec.Archive.Tar.Entry (
   DevMinor,
   TypeCode,
   Format(..),
+  These(..),
+  these,
 
   -- * Constructing simple entry values
   simpleEntry,

--- a/Codec/Archive/Tar/Index.hs
+++ b/Codec/Archive/Tar/Index.hs
@@ -702,7 +702,7 @@ example1 =
 testEntry :: FilePath -> Int64 -> Entry
 testEntry name size = simpleEntry path (NormalFile mempty size)
   where
-    Right path = toTarPath False name
+    That path = toTarPath False name
 
 -- | Simple tar archive containing regular files only
 data SimpleTarArchive = SimpleTarArchive {
@@ -767,7 +767,7 @@ instance Arbitrary SimpleTarArchive where
       mkList []            = []
       mkList ((fp, bs):es) = entry : mkList es
         where
-          Right path = toTarPath False fp
+          That path = toTarPath False fp
           entry   = simpleEntry path content
           content = NormalFile bs (LBS.length bs)
 

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -379,6 +379,11 @@ fromTarPathToWindowsPath (TarPath namebs prefixbs) = adjustDirectory $
 -- The conversion may fail if the 'FilePath' is too long. See 'TarPath' for a
 -- description of the problem with splitting long 'FilePath's.
 --
+-- Returns:
+-- 
+-- - 'This': on unrecoverable errors, such as 'FileNameEmpty'
+-- - 'That': on no errors
+-- - 'These': when the filepath is too long to fit into a tar 'Entry' and needs long filepath mangling via GNU extension
 toTarPath :: Bool -- ^ Is the path for a directory? This is needed because for
                   -- directories a 'TarPath' must always use a trailing @\/@.
           -> FilePath
@@ -404,7 +409,6 @@ instance Exception SplitError
 -- The strategy is this: take the name-directory components in reverse order
 -- and try to fit as many components into the 100 long name area as possible.
 -- If all the remaining components fit in the 155 name area then we win.
---
 splitLongPath :: FilePath -> These SplitError TarPath
 splitLongPath path =
   case packName nameMax (reverse (FilePath.Posix.splitPath path)) of

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -33,9 +33,11 @@ module Codec.Archive.Tar.Types (
   simpleEntry,
   longLinkEntry,
   fileEntry,
+  symlinkEntry,
   directoryEntry,
 
   ordinaryFilePermissions,
+  symbolicLinkPermission,
   executableFilePermissions,
   directoryPermissions,
 
@@ -198,6 +200,10 @@ instance NFData Ownership where
 ordinaryFilePermissions :: Permissions
 ordinaryFilePermissions   = 0o0644
 
+-- | @rw-r--r--@ for normal files
+symbolicLinkPermission :: Permissions
+symbolicLinkPermission   = 0o0777
+
 -- | @rwxr-xr-x@ for executable files
 executableFilePermissions :: Permissions
 executableFilePermissions = 0o0755
@@ -219,6 +225,7 @@ simpleEntry tarpath content = Entry {
     entryContent     = content,
     entryPermissions = case content of
                          Directory -> directoryPermissions
+                         SymbolicLink _ -> symbolicLinkPermission
                          _         -> ordinaryFilePermissions,
     entryOwnership   = Ownership "" "" 0 0,
     entryTime        = 0,
@@ -237,6 +244,12 @@ simpleEntry tarpath content = Entry {
 fileEntry :: TarPath -> LBS.ByteString -> Entry
 fileEntry name fileContent =
   simpleEntry name (NormalFile fileContent (LBS.length fileContent))
+
+
+-- | A tar 'Entry' for a symbolic link.
+symlinkEntry :: TarPath -> FilePath -> Entry
+symlinkEntry name targetLink =
+  simpleEntry name (SymbolicLink . LinkTarget . BS.Char8.pack $ targetLink)
 
 
 -- | Gnu entry for when a filepath is too long to be in entryTarPath.

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -73,6 +73,7 @@ import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS.Char8
 import qualified Data.ByteString.Lazy  as LBS
 import Control.DeepSeq
+import Control.Exception (Exception)
 
 import qualified System.FilePath as FilePath.Native
          ( joinPath, splitDirectories, addTrailingPathSeparator )
@@ -380,7 +381,8 @@ fromTarPathToWindowsPath (TarPath namebs prefixbs) = adjustDirectory $
 --
 toTarPath :: Bool -- ^ Is the path for a directory? This is needed because for
                   -- directories a 'TarPath' must always use a trailing @\/@.
-          -> FilePath -> These SplitError TarPath
+          -> FilePath
+          -> These SplitError TarPath
 toTarPath isDir = splitLongPath
                 . addTrailingSep
                 . FilePath.Posix.joinPath
@@ -392,6 +394,8 @@ toTarPath isDir = splitLongPath
 data SplitError = FileNameEmpty
                 | FileNameTooLong
                 deriving Show
+
+instance Exception SplitError
 
 
 -- | Take a sanitised path, split on directory separators and try to pack it
@@ -742,4 +746,3 @@ limitToV7FormatCompat entry@Entry { entryFormat = V7Format } =
 limitToV7FormatCompat entry = entry
 
 #endif
-

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -257,6 +257,9 @@ symlinkEntry name targetLink =
 -- Gnu tar uses OtherEntryType 'L' then as the first Entry and puts path
 -- in the entryContent. The Next entry will then be the "original"
 -- entry with the entryTarPath truncated.
+--
+-- So make sure this entry comes before the actual entry, when
+-- manually constructing entries.
 longLinkEntry :: FilePath -> Entry
 longLinkEntry tarpath = Entry {
     entryTarPath     = TarPath (BS.Char8.pack "././@LongLink") BS.empty,
@@ -383,7 +386,7 @@ fromTarPathToWindowsPath (TarPath namebs prefixbs) = adjustDirectory $
 -- 
 -- - 'This': on unrecoverable errors, such as 'FileNameEmpty'
 -- - 'That': on no errors
--- - 'These': when the filepath is too long to fit into a tar 'Entry' and needs long filepath mangling via GNU extension
+-- - 'These': when the filepath is too long to fit into a single tar 'Entry' and needs long filepath mangling via GNU extension. This can either be treated as an error (like older versions of 'tar') or be used with 'longLinkEntry' to create a comptabile set of entries.
 toTarPath :: Bool -- ^ Is the path for a directory? This is needed because for
                   -- directories a 'TarPath' must always use a trailing @\/@.
           -> FilePath

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar
@@ -27,13 +29,17 @@ import qualified System.FilePath as FilePath.Native
          ( takeDirectory )
 import System.Directory
          ( createDirectoryIfMissing, copyFile, getDirectoryContents, doesDirectoryExist )
+#if MIN_VERSION_directory(1,3,1)
+import System.Directory
+         ( createDirectoryLink, createFileLink )
+#endif
 import Control.Exception
          ( Exception, throwIO, handle )
 import System.IO.Error
          ( ioeGetErrorType )
 import GHC.IO (unsafeInterleaveIO)
 import Data.Foldable (traverse_)
-import GHC.IO.Exception (IOErrorType(InappropriateType))
+import GHC.IO.Exception (IOErrorType(InappropriateType, IllegalOperation, PermissionDenied, InvalidArgument))
 import System.Directory
          ( setModificationTime )
 import Data.Time.Clock.POSIX
@@ -72,9 +78,9 @@ unpack :: Exception e => FilePath -> Entries e -> IO ()
 unpack baseDir entries = do
   uEntries <- unpackEntries [] (checkSecurity entries)
   let (hardlinks, symlinks) = partition (\(_, _, x) -> x) uEntries
-  -- emulate hardlinks first, in case a symlink points to it
-  emulateLinks hardlinks
-  emulateLinks symlinks
+  -- handle hardlinks first, in case a symlink points to it
+  handleHardLinks hardlinks
+  handleSymlinks symlinks
 
   where
     -- We're relying here on 'checkSecurity' to make sure we're not scribbling
@@ -128,19 +134,53 @@ unpack baseDir entries = do
                                         $ (path, link', isHardLink):links
       where link' = fromLinkTarget link
 
-    emulateLinks = mapM_ $ \(relPath, relLinkTarget, isHardLink) ->
+
+    -- for hardlinks, we just copy
+    handleHardLinks = mapM_ $ \(relPath, relLinkTarget, _) ->
       let absPath   = baseDir </> relPath
           -- hard links link targets are always "absolute" paths in
           -- the context of the tar root
-          absTarget = if isHardLink then baseDir </> relLinkTarget else FilePath.Native.takeDirectory absPath </> relLinkTarget
-          -- need to handle cases where a symlink points to
-          -- a directory: https://github.com/haskell/tar/issues/35
-      in handle (\e -> if ioeGetErrorType e == InappropriateType
-                       then copyDirectoryRecursive absTarget absPath
-                       else throwIO e
-                )
-         $ copyFile absTarget absPath
+          absTarget = baseDir </> relLinkTarget
+      -- we don't expect races here, since we should be the
+      -- only process unpacking the tar archive and writing to
+      -- the destination
+      in doesDirectoryExist absTarget >>= \case
+          True -> copyDirectoryRecursive absTarget absPath
+          False -> copyFile absTarget absPath
 
+    -- For symlinks, we first try to recreate them and if that fails
+    -- with 'IllegalOperation', 'PermissionDenied' or 'InvalidArgument',
+    -- we fall back to copying.
+    -- This error handling isn't too fine grained and maybe should be
+    -- platform specific, but this way it might catch erros on unix even on
+    -- FAT32 fuse mounted volumes.
+    handleSymlinks = mapM_ $ \(relPath, relLinkTarget, _) ->
+      let absPath   = baseDir </> relPath
+          -- hard links link targets are always "absolute" paths in
+          -- the context of the tar root
+          absTarget = FilePath.Native.takeDirectory absPath </> relLinkTarget
+      -- we don't expect races here, since we should be the
+      -- only process unpacking the tar archive and writing to
+      -- the destination
+      in doesDirectoryExist absTarget >>= \case
+#if MIN_VERSION_directory(1,3,1)
+          True -> handleSymlinkError (copyDirectoryRecursive absTarget absPath)
+            $ createDirectoryLink relLinkTarget absPath
+          False -> handleSymlinkError (copyFile absTarget absPath)
+            $ createFileLink relLinkTarget absPath
+
+      where
+        handleSymlinkError action =
+          handle (\e -> if ioeGetErrorType e `elem` [IllegalOperation
+                                                    ,PermissionDenied
+                                                    ,InvalidArgument]
+                      then action
+                      else throwIO e
+                 )
+#else
+          True -> copyDirectoryRecursive absTarget absPath
+          False -> copyFile absTarget absPath
+#endif
 
 -- | Recursively copy the contents of one directory to another path.
 --

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: tar.cabal
+          htar/htar.cabal

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@ See also http://pvp.haskell.org/faq
 0.6.0.0 *TODO*
 
   * Add offending path as new field to `TarBombError` constructor
-  * Add support for over-long filepaths via GNU extension and fix hardlinks
+  * Add support for over-long filepaths via GNU extension
+  * Fix handling of hardlinks and symlinks
 
 0.5.1.1 Herbert Valerio Riedel <hvr@gnu.org> August 2019
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ See also http://pvp.haskell.org/faq
 0.6.0.0 *TODO*
 
   * Add offending path as new field to `TarBombError` constructor
+  * Add support for over-long filepaths via GNU extension and fix hardlinks
 
 0.5.1.1 Herbert Valerio Riedel <hvr@gnu.org> August 2019
 

--- a/htar/htar.cabal
+++ b/htar/htar.cabal
@@ -23,12 +23,12 @@ executable htar
   main-is: htar.hs
   ghc-options: -Wall
   build-depends:
-    base       >= 4.9 && < 5,
+    base       == 4.*,
     time       >= 1.1,
     directory  >= 1.0,
     filepath   >= 1.0,
     bytestring >= 0.9,
-    tar        >= 0.4.2,
+    tar        == 0.6.*,
     zlib       >= 0.4 && < 0.7,
     bzlib      >= 0.4 && < 0.7,
     time       >= 1.5


### PR DESCRIPTION
Fixes #49 And #51 

UTF8 filenames are still broken, but this is not in the scope of this PR. I tested this with the GHC bindist (packing and unpacking).