### PR TITLE
Rework checkEntrySecurity

### DIFF
--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -107,7 +107,7 @@ module Codec.Archive.Tar (
   -- device files.
   pack,
   unpack,
-  unpackRaw,
+  unpackWith,
 
   -- * Types
   -- ** Tar entry type

--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -131,6 +131,11 @@ module Codec.Archive.Tar (
   foldlEntries,
   unfoldEntries,
 
+  -- ** Long file names
+  encodeLongNames,
+  decodeLongNames,
+  DecodeLongNamesError(..),
+
   -- * Error handling
   -- | Reading tar files can fail if the data does not match the tar file
   -- format correctly.
@@ -146,6 +151,7 @@ module Codec.Archive.Tar (
   FormatError(..),
   ) where
 
+import Codec.Archive.Tar.LongNames
 import Codec.Archive.Tar.Types
 
 import Codec.Archive.Tar.Read

--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -115,6 +115,7 @@ module Codec.Archive.Tar (
   -- | This module provides only very simple and limited read-only access to
   -- the 'Entry' type. If you need access to the details or if you need to
   -- construct your own entries then also import "Codec.Archive.Tar.Entry".
+  GenEntry,
   Entry,
   entryPath,
   entryContent,
@@ -122,7 +123,8 @@ module Codec.Archive.Tar (
   EntryContent,
 
   -- ** Sequences of tar entries
-  Entries(..),
+  GenEntries(..),
+  Entries,
   mapEntries,
   mapEntriesNoFail,
   foldEntries,

--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -107,6 +107,7 @@ module Codec.Archive.Tar (
   -- device files.
   pack,
   unpack,
+  unpackRaw,
 
   -- * Types
   -- ** Tar entry type

--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -118,7 +118,8 @@ module Codec.Archive.Tar (
   Entry,
   entryPath,
   entryContent,
-  EntryContent(..),
+  GenEntryContent(..),
+  EntryContent,
 
   -- ** Sequences of tar entries
   Entries(..),

--- a/Codec/Archive/Tar.hs
+++ b/Codec/Archive/Tar.hs
@@ -106,6 +106,7 @@ module Codec.Archive.Tar (
   -- and permissions or to archive special files like named pipes and Unix
   -- device files.
   pack,
+  packWith,
   unpack,
   unpackWith,
 

--- a/Codec/Archive/Tar/Check/Internal.hs
+++ b/Codec/Archive/Tar/Check/Internal.hs
@@ -41,7 +41,7 @@ import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
 import Control.Exception (Exception(..))
 import qualified System.FilePath as FilePath.Native
-         ( splitDirectories, isAbsolute, isValid, (</>), takeDirectory )
+         ( splitDirectories, isAbsolute, isValid, (</>), takeDirectory, hasDrive )
 
 import qualified System.FilePath.Windows as FilePath.Windows
 import qualified System.FilePath.Posix   as FilePath.Posix
@@ -89,7 +89,7 @@ checkSecurity = go Nothing Nothing
       | otherwise = Nothing
 
     checkNative (fromFilePathToNative -> name)
-      | FilePath.Native.isAbsolute name
+      | FilePath.Native.isAbsolute name || FilePath.Native.hasDrive name
       = Just $ AbsoluteFileName name
       | not (FilePath.Native.isValid name)
       = Just $ InvalidFileName name

--- a/Codec/Archive/Tar/Check/Internal.hs
+++ b/Codec/Archive/Tar/Check/Internal.hs
@@ -78,11 +78,11 @@ checkSecurity mLink mPath e = do
   case entryContent e of
     HardLink     link ->
       let linkTarget = fromMaybe link mLink
-      in check (fromLinkTargetToUnix linkTarget)
+      in check (fromLinkTargetToPosixPath linkTarget)
     SymbolicLink link ->
       let linkTarget = fromMaybe link mLink
       in check (FilePath.Posix.takeDirectory (fromTarPathToPosixPath . entryTarPath $ e)
-               FilePath.Posix.</> fromLinkTargetToUnix linkTarget)
+               FilePath.Posix.</> fromLinkTargetToPosixPath linkTarget)
     _                 -> pure ()
   where
     checkPosix name

--- a/Codec/Archive/Tar/Check/Internal.hs
+++ b/Codec/Archive/Tar/Check/Internal.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar.Check.Internal
@@ -35,13 +39,21 @@ import Control.Applicative ((<|>))
 import qualified Data.ByteString.Lazy.Char8 as Char8
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
-import Control.Exception (Exception)
+import Control.Exception (Exception(..))
 import qualified System.FilePath as FilePath.Native
          ( splitDirectories, isAbsolute, isValid, (</>), takeDirectory )
 
 import qualified System.FilePath.Windows as FilePath.Windows
 import qualified System.FilePath.Posix   as FilePath.Posix
 
+instance forall e1 e2 . (Exception e1, Exception e2) => Exception (Either e1 e2) where
+  toException (Left e)  = toException e
+  toException (Right e) = toException e
+  fromException se = case fromException @e1 se of
+                       Nothing -> Right <$> fromException @e2 se
+                       Just e  -> Just (Left e)
+  displayException (Left e)  = displayException e
+  displayException (Right e) = displayException e
 
 --------------------------
 -- Security

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -25,14 +25,11 @@
 module Codec.Archive.Tar.Entry (
 
   -- * Tar entry and associated types
-  Entry(..),
-  --TODO: should be the following with the Entry constructor not exported,
-  --      but haddock cannot document that properly
-  --      see http://trac.haskell.org/haddock/ticket/3
-  --Entry(filePath, fileMode, ownerId, groupId, fileSize, modTime,
-  --      fileType, linkTarget, headerExt, fileContent),
+  GenEntry(..),
+  Entry,
   entryPath,
-  EntryContent(..),
+  GenEntryContent(..),
+  EntryContent,
   Ownership(..),
 
   FileSize,

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -75,7 +75,7 @@ module Codec.Archive.Tar.Entry (
   toLinkTarget,
   fromLinkTarget,
   fromLinkTargetToPosixPath,
-
+  fromLinkTargetToWindowsPath,
   ) where
 
 import Codec.Archive.Tar.Types

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -73,7 +73,7 @@ module Codec.Archive.Tar.Entry (
   -- * LinkTarget type
   LinkTarget,
   toLinkTarget,
-  fromLinkTargetToNative,
+  fromLinkTarget,
   fromLinkTargetToUnix,
 
   ) where

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -73,9 +73,8 @@ module Codec.Archive.Tar.Entry (
   -- * LinkTarget type
   LinkTarget,
   toLinkTarget,
-  fromLinkTarget,
-  fromLinkTargetToPosixPath,
-  fromLinkTargetToWindowsPath,
+  fromLinkTargetToNative,
+  fromLinkTargetToUnix,
 
   ) where
 

--- a/Codec/Archive/Tar/Entry.hs
+++ b/Codec/Archive/Tar/Entry.hs
@@ -74,7 +74,7 @@ module Codec.Archive.Tar.Entry (
   LinkTarget,
   toLinkTarget,
   fromLinkTarget,
-  fromLinkTargetToUnix,
+  fromLinkTargetToPosixPath,
 
   ) where
 

--- a/Codec/Archive/Tar/LongNames.hs
+++ b/Codec/Archive/Tar/LongNames.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Codec.Archive.Tar.LongNames
+  ( encodeLongNames
+  , decodeLongNames
+  , DecodeLongNamesError
+  ) where
+
+import Codec.Archive.Tar.Types
+import Control.Exception
+import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+data DecodeLongNamesError
+  = TwoTypeKEntries
+  | TwoTypeLEntries
+  | NoLinkEntryAfterTypeKEntry
+  deriving (Eq, Ord, Show)
+
+instance Exception DecodeLongNamesError
+
+encodeLongNames
+  :: GenEntry FilePath FilePath
+  -> [Entry]
+encodeLongNames e = maybe id (:) mEntry $ maybe id (:) mEntry' [e'']
+  where
+    (mEntry, e') = encodeLinkTarget e
+    (mEntry', e'') = encodeTarPath e'
+
+encodeTarPath
+  :: GenEntry FilePath linkTarget
+  -> (Maybe (GenEntry TarPath whatever), GenEntry TarPath linkTarget)
+  -- ^ (LongLink entry, actual entry)
+encodeTarPath e = case toTarPath' (entryTarPath e) of
+  FileNameEmpty -> (Nothing, e { entryTarPath = TarPath mempty mempty })
+  FileNameOK tarPath -> (Nothing, e { entryTarPath = tarPath })
+  FileNameTooLong tarPath -> (Just $ longLinkEntry $ entryTarPath e, e { entryTarPath = tarPath })
+
+encodeLinkTarget
+  :: GenEntry tarPath FilePath
+  -> (Maybe (GenEntry TarPath LinkTarget), GenEntry tarPath LinkTarget)
+  -- ^ (LongLink symlink entry, actual entry)
+encodeLinkTarget e = case entryContent e of
+  NormalFile x y -> (Nothing, e { entryContent = NormalFile x y })
+  Directory -> (Nothing, e { entryContent = Directory })
+  SymbolicLink lnk -> let (mEntry, lnk') = encodeLinkPath lnk in
+    (mEntry, e { entryContent = SymbolicLink lnk' })
+  HardLink lnk -> let (mEntry, lnk') = encodeLinkPath lnk in
+    (mEntry, e { entryContent = HardLink lnk' })
+  CharacterDevice x y -> (Nothing, e { entryContent = CharacterDevice x y })
+  BlockDevice x y -> (Nothing, e { entryContent = BlockDevice x y })
+  NamedPipe -> (Nothing, e { entryContent = NamedPipe })
+  OtherEntryType x y z -> (Nothing, e { entryContent = OtherEntryType x y z })
+
+encodeLinkPath
+  :: FilePath
+  -> (Maybe (GenEntry TarPath LinkTarget), LinkTarget)
+encodeLinkPath lnk = case toTarPath' lnk of
+  FileNameEmpty -> (Nothing, LinkTarget mempty)
+  FileNameOK (TarPath name prefix)
+    | B.null prefix -> (Nothing, LinkTarget name)
+    | otherwise -> (Just $ longSymLinkEntry lnk, LinkTarget name)
+  FileNameTooLong (TarPath name _) ->
+    (Just $ longSymLinkEntry lnk, LinkTarget name)
+
+-- | Resolved 'FilePath's are still POSIX file names, not native ones.
+decodeLongNames
+  :: Entries e
+  -> GenEntries FilePath FilePath (Either e DecodeLongNamesError)
+decodeLongNames = go Nothing Nothing
+  where
+    go :: Maybe FilePath -> Maybe FilePath -> Entries e -> GenEntries FilePath FilePath (Either e DecodeLongNamesError)
+    go _ _ (Fail err) = Fail (Left err)
+    go _ _ Done = Done
+
+    go Nothing Nothing (Next e rest) = case entryContent e of
+      OtherEntryType 'K' fn _ ->
+        go (Just (otherEntryPayloadToFilePath fn)) Nothing rest
+      OtherEntryType 'L' fn _ ->
+        go Nothing (Just (otherEntryPayloadToFilePath fn)) rest
+      _ ->
+        Next (castEntry e) (go Nothing Nothing rest)
+
+    go Nothing (Just path) (Next e rest) = case entryContent e of
+      OtherEntryType 'K' fn _ ->
+        go (Just (otherEntryPayloadToFilePath fn)) (Just path) rest
+      OtherEntryType 'L' _ _ ->
+        Fail $ Right TwoTypeLEntries
+      _ -> Next ((castEntry e) { entryTarPath = path }) (go Nothing Nothing rest)
+
+    go (Just link) Nothing (Next e rest) = case entryContent e of
+      OtherEntryType 'K' _ _ ->
+        Fail $ Right TwoTypeKEntries
+      OtherEntryType 'L' fn _ ->
+        go (Just link) (Just (otherEntryPayloadToFilePath fn)) rest
+      SymbolicLink{} ->
+        Next ((castEntry e) { entryContent = SymbolicLink link }) (go Nothing Nothing rest)
+      HardLink{} ->
+        Next ((castEntry e) { entryContent = HardLink link }) (go Nothing Nothing rest)
+      _ ->
+        Fail $ Right NoLinkEntryAfterTypeKEntry
+
+    go (Just link) (Just path) (Next e rest) = case entryContent e of
+      OtherEntryType 'K' _ _ ->
+        Fail $ Right TwoTypeKEntries
+      OtherEntryType 'L' _ _ ->
+        Fail $ Right TwoTypeLEntries
+      SymbolicLink{} ->
+        Next ((castEntry e) { entryTarPath = path, entryContent = SymbolicLink link }) (go Nothing Nothing rest)
+      HardLink{} ->
+        Next ((castEntry e) { entryTarPath = path, entryContent = HardLink link }) (go Nothing Nothing rest)
+      _ ->
+        Fail $ Right NoLinkEntryAfterTypeKEntry
+
+otherEntryPayloadToFilePath :: BL.ByteString -> FilePath
+otherEntryPayloadToFilePath = B.unpack . B.takeWhile (/= '\0') . BL.toStrict
+
+castEntry :: Entry -> GenEntry FilePath FilePath
+castEntry e = e
+  { entryTarPath = fromTarPathToPosixPath (entryTarPath e)
+  , entryContent = castEntryContent (entryContent e)
+  }
+
+castEntryContent :: EntryContent -> GenEntryContent FilePath
+castEntryContent = \case
+  NormalFile x y -> NormalFile x y
+  Directory -> Directory
+  SymbolicLink linkTarget -> SymbolicLink $ fromLinkTargetToPosixPath linkTarget
+  HardLink linkTarget -> HardLink $ fromLinkTargetToPosixPath linkTarget
+  CharacterDevice x y -> CharacterDevice x y
+  BlockDevice x y -> BlockDevice x y
+  NamedPipe -> NamedPipe
+  OtherEntryType x y z -> OtherEntryType x y z

--- a/Codec/Archive/Tar/LongNames.hs
+++ b/Codec/Archive/Tar/LongNames.hs
@@ -3,7 +3,7 @@
 module Codec.Archive.Tar.LongNames
   ( encodeLongNames
   , decodeLongNames
-  , DecodeLongNamesError
+  , DecodeLongNamesError(..)
   ) where
 
 import Codec.Archive.Tar.Types

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -97,7 +97,8 @@ packPaths baseDir paths =
                  packSymlinkEntry' linkTarget tarpath >>= \case
                    sym@(Entry { entryContent = SymbolicLink (LinkTarget bs) })
                      | BSS.length bs > 100 -> do
-                        pure [longSymLinkEntry linkTarget, longLinkEntry relpath, sym]
+                        longEntry <- longSymLinkEntry linkTarget
+                        pure [longEntry, longLinkEntry relpath, sym]
                    _ -> withLongLinkEntry relpath tarpath packSymlinkEntry
              | isDir     -> withLongLinkEntry relpath tarpath packDirectoryEntry
              | otherwise -> withLongLinkEntry relpath tarpath packFileEntry
@@ -176,9 +177,9 @@ packSymlinkEntry' :: String   -- ^ link target
                   -> TarPath  -- ^ Path to use for the tar Entry in the archive
                   -> IO Entry
 packSymlinkEntry' linkTarget tarpath = do
-  let entry tp = symlinkEntry tp linkTarget
-      safeReturn tp = maybe (pure tp) throwIO $ checkEntrySecurity tp
-  safeReturn $ entry tarpath
+  let safeReturn entry = maybe (pure entry) throwIO $ checkEntrySecurity entry
+  entry <- symlinkEntry tarpath linkTarget
+  safeReturn entry
 
 -- | This is a utility function, much like 'listDirectory'. The
 -- difference is that it includes the contents of subdirectories.

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -68,6 +68,10 @@ pack :: FilePath   -- ^ Base directory
      -> IO [Entry]
 pack = packWith checkSecurity
 
+-- | Like 'pack', but does not perform any sanity/security checks on the input.
+-- You can do so yourself, e.g.: @packWith@ 'checkSecurity' @dir@ @files@.
+--
+-- @since 0.6.0.0
 packWith :: CheckSecurityCallback
          -> FilePath   -- ^ Base directory
          -> [FilePath] -- ^ Files and directories to pack, relative to the base dir

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -98,9 +98,18 @@ packPaths secCB baseDir paths =
          case tarpathRes of
            FileNameEmpty -> throwIO $ userError "File name empty"
            FileNameOK tarpath
-             | isSymlink -> (:[]) <$> packSymlinkEntry abspath tarpath
-             | isDir     -> (:[]) <$> packDirectoryEntry abspath tarpath
-             | otherwise -> (:[]) <$> packFileEntry abspath tarpath
+             | isSymlink -> do
+                 e <- packSymlinkEntry abspath tarpath
+                 secCB Nothing Nothing e
+                 pure [e]
+             | isDir     -> do
+                 e <- packDirectoryEntry abspath tarpath
+                 secCB Nothing Nothing e
+                 pure [e]
+             | otherwise -> do
+                 e <- packFileEntry abspath tarpath
+                 secCB Nothing Nothing e
+                 pure [e]
            FileNameTooLong tarpath
              | isSymlink -> do
                  linkTarget <- getSymbolicLinkTarget abspath

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -70,7 +70,8 @@ preparePaths baseDir = fmap concat . interleave . map go
     go relpath = do
       let abspath = baseDir </> relpath
       isDir  <- doesDirectoryExist abspath
-      if isDir then do
+      isSymlink <- pathIsSymbolicLink abspath
+      if isDir && not isSymlink then do
         entries <- getDirectoryContentsRecursive abspath
         let entries' = map (relpath </>) entries
         return $ if null relpath
@@ -215,7 +216,8 @@ recurseDirectories base (dir:dirs) = unsafeInterleaveIO $ do
       let dirEntry  = dir </> entry
           dirEntry' = FilePath.Native.addTrailingPathSeparator dirEntry
       isDirectory <- doesDirectoryExist (base </> dirEntry)
-      if isDirectory
+      isSymlink <- pathIsSymbolicLink (base </> dirEntry)
+      if isDirectory && not isSymlink
         then collect files (dirEntry':dirs') entries
         else collect (dirEntry:files) dirs' entries
 

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar
@@ -15,6 +17,7 @@
 -----------------------------------------------------------------------------
 module Codec.Archive.Tar.Pack (
     pack,
+    packWith,
     packFileEntry,
     packDirectoryEntry,
     packSymlinkEntry,
@@ -63,7 +66,13 @@ import Codec.Archive.Tar.Check.Internal (checkSecurity)
 pack :: FilePath   -- ^ Base directory
      -> [FilePath] -- ^ Files and directories to pack, relative to the base dir
      -> IO [Entry]
-pack baseDir = preparePaths baseDir >=> packPaths baseDir
+pack = packWith checkSecurity
+
+packWith :: CheckSecurityCallback
+         -> FilePath   -- ^ Base directory
+         -> [FilePath] -- ^ Files and directories to pack, relative to the base dir
+         -> IO [Entry]
+packWith secCB baseDir = preparePaths baseDir >=> packPaths secCB baseDir
 
 preparePaths :: FilePath -> [FilePath] -> IO [FilePath]
 preparePaths baseDir = fmap concat . interleave . map go
@@ -81,8 +90,8 @@ preparePaths baseDir = fmap concat . interleave . map go
       else return [relpath]
 
 -- | Pack paths while accounting for overlong filepaths.
-packPaths :: FilePath -> [FilePath] -> IO [Entry]
-packPaths baseDir paths =
+packPaths :: CheckSecurityCallback -> FilePath -> [FilePath] -> IO [Entry]
+packPaths secCB baseDir paths =
   concat <$> interleave
     [ do let tarpathRes = toTarPath' relpath
          isSymlink <- pathIsSymbolicLink abspath
@@ -99,7 +108,7 @@ packPaths baseDir paths =
                    sym@(Entry { entryContent = SymbolicLink (LinkTarget bs) })
                      | BSS.length bs > 100 -> do
                         longEntry <- longSymLinkEntry linkTarget
-                        checkSecurity (Just (LinkTarget bs)) (Just relpath) sym
+                        secCB (Just (LinkTarget bs)) (Just relpath) sym
                         pure [longEntry, longLinkEntry relpath, sym]
                    _ -> withLongLinkEntry relpath tarpath packSymlinkEntry
              | isDir     -> withLongLinkEntry relpath tarpath packDirectoryEntry
@@ -117,7 +126,7 @@ packPaths baseDir paths =
       -> IO [Entry]
     withLongLinkEntry relpath tarpath f = do
       mainEntry <- f (baseDir </> relpath) tarpath
-      checkSecurity Nothing (Just relpath) mainEntry
+      secCB Nothing (Just relpath) mainEntry
       pure [longLinkEntry relpath, mainEntry]
 
 interleave :: [IO a] -> IO [a]

--- a/Codec/Archive/Tar/Pack.hs
+++ b/Codec/Archive/Tar/Pack.hs
@@ -66,7 +66,7 @@ pack baseDir paths0 = preparePaths baseDir paths0 >>= packPaths baseDir
 
 preparePaths :: FilePath -> [FilePath] -> IO [FilePath]
 preparePaths baseDir paths =
-  fmap concat $ interleave
+  concat <$> interleave
     [ do isDir  <- doesDirectoryExist (baseDir </> path)
          if isDir
            then do entries <- getDirectoryContentsRecursive (baseDir </> path)
@@ -81,28 +81,28 @@ preparePaths baseDir paths =
 -- | Pack paths while accounting for overlong filepaths.
 packPaths :: FilePath -> [FilePath] -> IO [Entry]
 packPaths baseDir paths =
-  fmap concat $ interleave
+  concat <$> interleave
     [ do let tarpathRes = toTarPath' relpath
-         isSymlink <- pathIsSymbolicLink filepath
+         isSymlink <- pathIsSymbolicLink abspath
          case tarpathRes of
            FileNameEmpty -> throwIO $ userError "File name empty"
            FileNameOK tarpath
-             | isSymlink -> (:[]) <$> packSymlinkEntry filepath tarpath
-             | isDir     -> (:[]) <$> packDirectoryEntry filepath tarpath
-             | otherwise -> (:[]) <$> packFileEntry filepath tarpath
+             | isSymlink -> (:[]) <$> packSymlinkEntry abspath tarpath
+             | isDir     -> (:[]) <$> packDirectoryEntry abspath tarpath
+             | otherwise -> (:[]) <$> packFileEntry abspath tarpath
            FileNameTooLong tarpath
              | isSymlink -> do
-                 linkTarget <- getSymbolicLinkTarget filepath
+                 linkTarget <- getSymbolicLinkTarget abspath
                  packSymlinkEntry' linkTarget tarpath >>= \case
                    sym@(Entry { entryContent = SymbolicLink (LinkTarget bs) })
                      | BSS.length bs > 100 -> do
-                        pure [longSymLinkEntry linkTarget, longLinkEntry filepath, sym]
-                   _ -> withLongLinkEntry filepath tarpath packSymlinkEntry
-             | isDir     -> withLongLinkEntry filepath tarpath packDirectoryEntry
-             | otherwise -> withLongLinkEntry filepath tarpath packFileEntry
+                        pure [longSymLinkEntry linkTarget, longLinkEntry relpath, sym]
+                   _ -> withLongLinkEntry relpath tarpath packSymlinkEntry
+             | isDir     -> withLongLinkEntry relpath tarpath packDirectoryEntry
+             | otherwise -> withLongLinkEntry relpath tarpath packFileEntry
     | relpath <- paths
-    , let isDir    = FilePath.Native.hasTrailingPathSeparator filepath
-          filepath = baseDir </> relpath ]
+    , let isDir    = FilePath.Native.hasTrailingPathSeparator abspath
+          abspath = baseDir </> relpath ]
   where
     -- prepend the long filepath entry if necessary
     withLongLinkEntry
@@ -110,9 +110,9 @@ packPaths baseDir paths =
       -> TarPath
       -> (FilePath -> TarPath -> IO Entry)
       -> IO [Entry]
-    withLongLinkEntry filepath tarpath f = do
-      mainEntry <- f filepath tarpath
-      pure [longLinkEntry filepath, mainEntry]
+    withLongLinkEntry relpath tarpath f = do
+      mainEntry <- f (baseDir </> relpath) tarpath
+      pure [longLinkEntry relpath, mainEntry]
 
 interleave :: [IO a] -> IO [a]
 interleave = unsafeInterleaveIO . go

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -55,6 +55,7 @@ module Codec.Archive.Tar.Types (
   toLinkTarget',
   fromLinkTarget,
   fromLinkTargetToPosixPath,
+  fromLinkTargetToWindowsPath,
 
   Entries(..),
   mapEntries,
@@ -509,6 +510,11 @@ fromLinkTarget (LinkTarget pathbs) = fromFilePathToNative $ BS.Char8.unpack path
 fromLinkTargetToPosixPath :: LinkTarget -> FilePath
 fromLinkTargetToPosixPath (LinkTarget pathbs) = BS.Char8.unpack pathbs
 
+-- | Convert a tar 'LinkTarget' to a Windows 'FilePath' (@\'\\\\\'@ path separators).
+fromLinkTargetToWindowsPath :: LinkTarget -> FilePath
+fromLinkTargetToWindowsPath (LinkTarget pathbs) =
+  fromFilePathToWindowsPath $ BS.Char8.unpack pathbs
+
 -- | Convert a unix FilePath to a native 'FilePath'.
 fromFilePathToNative :: FilePath -> FilePath
 fromFilePathToNative path = adjustDirectory $
@@ -518,6 +524,14 @@ fromFilePathToNative path = adjustDirectory $
                     = FilePath.Native.addTrailingPathSeparator
                     | otherwise = id
 
+-- | Convert a unix FilePath to a Windows 'FilePath'.
+fromFilePathToWindowsPath :: FilePath -> FilePath
+fromFilePathToWindowsPath path = adjustDirectory $
+  FilePath.Windows.joinPath $ FilePath.Posix.splitDirectories path
+  where
+    adjustDirectory | FilePath.Posix.hasTrailingPathSeparator path
+                    = FilePath.Windows.addTrailingPathSeparator
+                    | otherwise = id
 
 --
 -- * Entries type

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -635,4 +635,13 @@ instance NFData e => NFData (Entries e) where
   rnf  Done       = ()
   rnf (Fail e)    = rnf e
 
-type CheckSecurityCallback = forall m. MonadThrow m => Maybe LinkTarget -> Maybe FilePath -> Entry -> m ()
+-- | @since 0.6.0.0
+type CheckSecurityCallback =
+  forall m.
+     MonadThrow m
+  => Maybe LinkTarget
+  -- ^ OtherEntryType 'K' discovered before the actual entry
+  -> Maybe FilePath
+  -- ^ OtherEntryType 'L' discovered before the actual entry
+  -> Entry
+  -> m ()

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -53,7 +53,7 @@ module Codec.Archive.Tar.Types (
   LinkTarget(..),
   toLinkTarget,
   toLinkTarget',
-  fromLinkTargetToNative,
+  fromLinkTarget,
   fromLinkTargetToUnix,
 
   Entries(..),
@@ -502,8 +502,8 @@ toLinkTarget' path
                     | otherwise = id
 
 -- | Convert a tar 'LinkTarget' to a native 'FilePath'.
-fromLinkTargetToNative :: LinkTarget -> FilePath
-fromLinkTargetToNative (LinkTarget pathbs) = fromFilePathToNative $ BS.Char8.unpack pathbs
+fromLinkTarget :: LinkTarget -> FilePath
+fromLinkTarget (LinkTarget pathbs) = fromFilePathToNative $ BS.Char8.unpack pathbs
 
 -- | Convert a tar 'LinkTarget' to a unix 'FilePath'.
 fromLinkTargetToUnix :: LinkTarget -> FilePath

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -47,6 +47,7 @@ module Codec.Archive.Tar.Types (
   fromTarPath,
   fromTarPathToPosixPath,
   fromTarPathToWindowsPath,
+  fromFilePathToNative,
 
   LinkTarget(..),
   toLinkTarget,
@@ -501,17 +502,20 @@ toLinkTarget' path
 
 -- | Convert a tar 'LinkTarget' to a native 'FilePath'.
 fromLinkTargetToNative :: LinkTarget -> FilePath
-fromLinkTargetToNative (LinkTarget pathbs) = adjustDirectory $
-  FilePath.Native.joinPath $ FilePath.Posix.splitDirectories path
-  where
-    path = BS.Char8.unpack pathbs
-    adjustDirectory | FilePath.Posix.hasTrailingPathSeparator path
-                    = FilePath.Native.addTrailingPathSeparator
-                    | otherwise = id
+fromLinkTargetToNative (LinkTarget pathbs) = fromFilePathToNative $ BS.Char8.unpack pathbs
 
 -- | Convert a tar 'LinkTarget' to a unix 'FilePath'.
 fromLinkTargetToUnix :: LinkTarget -> FilePath
 fromLinkTargetToUnix (LinkTarget pathbs) = BS.Char8.unpack pathbs
+
+-- | Convert a unix FilePath to a native 'FilePath'.
+fromFilePathToNative :: FilePath -> FilePath
+fromFilePathToNative path = adjustDirectory $
+  FilePath.Native.joinPath $ FilePath.Posix.splitDirectories path
+  where
+    adjustDirectory | FilePath.Posix.hasTrailingPathSeparator path
+                    = FilePath.Native.addTrailingPathSeparator
+                    | otherwise = id
 
 
 --

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, BangPatterns, DeriveTraversable #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, BangPatterns, DeriveTraversable, ScopedTypeVariables, RankNTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar.Types
@@ -27,6 +27,7 @@ module Codec.Archive.Tar.Types (
   DevMajor,
   DevMinor,
   Format(..),
+  CheckSecurityCallback,
 
   simpleEntry,
   longLinkEntry,
@@ -619,3 +620,5 @@ instance NFData e => NFData (Entries e) where
   rnf (Next e es) = rnf e `seq` rnf es
   rnf  Done       = ()
   rnf (Fail e)    = rnf e
+
+type CheckSecurityCallback = forall m. MonadThrow m => Maybe LinkTarget -> Maybe FilePath -> Entry -> m ()

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -50,9 +50,9 @@ module Codec.Archive.Tar.Types (
 
   LinkTarget(..),
   toLinkTarget,
-  fromLinkTarget,
-  fromLinkTargetToPosixPath,
-  fromLinkTargetToWindowsPath,
+  toLinkTarget',
+  fromLinkTargetToNative,
+  fromLinkTargetToUnix,
 
   Entries(..),
   mapEntries,
@@ -66,14 +66,16 @@ import Data.Int      (Int64)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid   (Monoid(..))
 import Data.Semigroup as Sem
+import Data.Typeable
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS.Char8
 import qualified Data.ByteString.Lazy  as LBS
 import Control.DeepSeq
-import Control.Exception (Exception)
+import Control.Exception (Exception, displayException)
+import Control.Monad.Catch (MonadThrow, throwM)
 
 import qualified System.FilePath as FilePath.Native
-         ( joinPath, splitDirectories, addTrailingPathSeparator, hasTrailingPathSeparator, pathSeparator )
+         ( joinPath, splitDirectories, addTrailingPathSeparator, hasTrailingPathSeparator, pathSeparator, isAbsolute, hasTrailingPathSeparator )
 import qualified System.FilePath.Posix as FilePath.Posix
          ( joinPath, splitPath, splitDirectories, hasTrailingPathSeparator
          , addTrailingPathSeparator, pathSeparator )
@@ -243,9 +245,10 @@ fileEntry name fileContent =
 
 
 -- | A tar 'Entry' for a symbolic link.
-symlinkEntry :: TarPath -> FilePath -> Entry
-symlinkEntry name targetLink =
-  simpleEntry name (SymbolicLink . LinkTarget . packAscii $ targetLink)
+symlinkEntry :: MonadThrow m => TarPath -> FilePath -> m Entry
+symlinkEntry name targetLink = do
+  target <- toLinkTarget' targetLink
+  pure $ simpleEntry name (SymbolicLink . LinkTarget . packAscii $ target)
 
 -- | [GNU extension](https://www.gnu.org/software/tar/manual/html_node/Standard.html)
 -- to store a filepath too long to fit into 'entryTarPath'
@@ -273,10 +276,12 @@ longLinkEntry tarpath = Entry {
 -- data with truncated 'entryTarPath'.
 --
 -- @since 0.6.0.0
-longSymLinkEntry :: FilePath -> Entry
-longSymLinkEntry linkTarget = Entry {
+longSymLinkEntry :: MonadThrow m => FilePath -> m Entry
+longSymLinkEntry linkTarget = do
+  target <- toLinkTarget' linkTarget
+  pure $ Entry {
     entryTarPath     = TarPath (BS.Char8.pack "././@LongLink") BS.empty,
-    entryContent     = OtherEntryType 'K' (LBS.fromStrict $ packAscii linkTarget) (fromIntegral $ length linkTarget),
+    entryContent     = OtherEntryType 'K' (LBS.fromStrict . packAscii $ target) (fromIntegral $ length target),
     entryPermissions = ordinaryFilePermissions,
     entryOwnership   = Ownership "" "" 0 0,
     entryTime        = 0,
@@ -466,18 +471,37 @@ newtype LinkTarget = LinkTarget BS.ByteString
 instance NFData LinkTarget where
     rnf (LinkTarget bs) = rnf bs
 
--- | Convert a native 'FilePath' to a tar 'LinkTarget'. This may fail if the
+-- | Convert a native 'FilePath' to a tar 'LinkTarget'.
 -- string is longer than 100 characters or if it contains non-portable
 -- characters.
---
-toLinkTarget   :: FilePath -> Maybe LinkTarget
-toLinkTarget path | length path <= 100 = Just $! LinkTarget (packAscii path)
-                  | otherwise          = Nothing
+toLinkTarget   :: MonadThrow m => FilePath -> m LinkTarget
+toLinkTarget path | length path <= 100 = do
+                                           target <- toLinkTarget' path
+                                           pure $! LinkTarget (packAscii target)
+                  | otherwise          = throwM (TooLong path)
+
+data LinkTargetException = IsAbsolute FilePath
+                         | TooLong FilePath
+  deriving (Show,Typeable)
+
+instance Exception LinkTargetException where
+  displayException (IsAbsolute fp) = "Link target \"" <> fp <> "\" is unexpectedly absolute"
+  displayException (TooLong _) = "The link target is too long"
+
+-- | Convert a native 'FilePath' to a unix filepath suitable for
+-- using as 'LinkTarget'. Does not error if longer than 100 characters.
+toLinkTarget' :: MonadThrow m => FilePath -> m FilePath
+toLinkTarget' path
+  | FilePath.Native.isAbsolute path = throwM (IsAbsolute path)
+  | otherwise = pure $ adjustDirectory $ FilePath.Posix.joinPath $ FilePath.Native.splitDirectories path
+  where
+    adjustDirectory | FilePath.Native.hasTrailingPathSeparator path
+                    = FilePath.Posix.addTrailingPathSeparator
+                    | otherwise = id
 
 -- | Convert a tar 'LinkTarget' to a native 'FilePath'.
---
-fromLinkTarget :: LinkTarget -> FilePath
-fromLinkTarget (LinkTarget pathbs) = adjustDirectory $
+fromLinkTargetToNative :: LinkTarget -> FilePath
+fromLinkTargetToNative (LinkTarget pathbs) = adjustDirectory $
   FilePath.Native.joinPath $ FilePath.Posix.splitDirectories path
   where
     path = BS.Char8.unpack pathbs
@@ -485,27 +509,10 @@ fromLinkTarget (LinkTarget pathbs) = adjustDirectory $
                     = FilePath.Native.addTrailingPathSeparator
                     | otherwise = id
 
--- | Convert a tar 'LinkTarget' to a Unix/Posix 'FilePath'.
---
-fromLinkTargetToPosixPath :: LinkTarget -> FilePath
-fromLinkTargetToPosixPath (LinkTarget pathbs) = adjustDirectory $
-  FilePath.Posix.joinPath $ FilePath.Posix.splitDirectories path
-  where
-    path = BS.Char8.unpack pathbs
-    adjustDirectory | FilePath.Posix.hasTrailingPathSeparator path
-                    = FilePath.Native.addTrailingPathSeparator
-                    | otherwise = id
+-- | Convert a tar 'LinkTarget' to a unix 'FilePath'.
+fromLinkTargetToUnix :: LinkTarget -> FilePath
+fromLinkTargetToUnix (LinkTarget pathbs) = BS.Char8.unpack pathbs
 
--- | Convert a tar 'LinkTarget' to a Windows 'FilePath'.
---
-fromLinkTargetToWindowsPath :: LinkTarget -> FilePath
-fromLinkTargetToWindowsPath (LinkTarget pathbs) = adjustDirectory $
-  FilePath.Windows.joinPath $ FilePath.Posix.splitDirectories path
-  where
-    path = BS.Char8.unpack pathbs
-    adjustDirectory | FilePath.Posix.hasTrailingPathSeparator path
-                    = FilePath.Windows.addTrailingPathSeparator
-                    | otherwise = id
 
 --
 -- * Entries type

--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -54,7 +54,7 @@ module Codec.Archive.Tar.Types (
   toLinkTarget,
   toLinkTarget',
   fromLinkTarget,
-  fromLinkTargetToUnix,
+  fromLinkTargetToPosixPath,
 
   Entries(..),
   mapEntries,
@@ -505,9 +505,9 @@ toLinkTarget' path
 fromLinkTarget :: LinkTarget -> FilePath
 fromLinkTarget (LinkTarget pathbs) = fromFilePathToNative $ BS.Char8.unpack pathbs
 
--- | Convert a tar 'LinkTarget' to a unix 'FilePath'.
-fromLinkTargetToUnix :: LinkTarget -> FilePath
-fromLinkTargetToUnix (LinkTarget pathbs) = BS.Char8.unpack pathbs
+-- | Convert a tar 'LinkTarget' to a Unix\/POSIX 'FilePath' (@\'/\'@ path separators).
+fromLinkTargetToPosixPath :: LinkTarget -> FilePath
+fromLinkTargetToPosixPath (LinkTarget pathbs) = BS.Char8.unpack pathbs
 
 -- | Convert a unix FilePath to a native 'FilePath'.
 fromFilePathToNative :: FilePath -> FilePath

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Codec.Archive.Tar
@@ -14,12 +16,13 @@
 -----------------------------------------------------------------------------
 module Codec.Archive.Tar.Unpack (
   unpack,
-  unpackRaw,
+  unpackWith,
   ) where
 
 import Codec.Archive.Tar.Types
 import Codec.Archive.Tar.Check
 
+import Control.Monad.Catch (MonadThrow, throwM)
 import Data.Bits
          ( testBit )
 import Data.List (partition, nub)
@@ -56,6 +59,10 @@ import Data.Time.Clock.POSIX
 import Control.Exception as Exception
          ( catch )
 
+
+type CheckSecurityCallback = forall m. MonadThrow m => Maybe LinkTarget -> Maybe FilePath -> Entry -> m ()
+
+
 -- | Create local files and directories based on the entries of a tar archive.
 --
 -- This is a portable implementation of unpacking suitable for portable
@@ -81,14 +88,14 @@ import Control.Exception as Exception
 -- use 'checkSecurity' before 'checkTarbomb' or other checks.
 --
 unpack :: Exception e => FilePath -> Entries e -> IO ()
-unpack baseDir entries = unpackRaw baseDir (checkSecurity entries)
+unpack = unpackWith checkSecurity
 
 -- | Like 'unpack', but does not perform any sanity/security checks on the tar entries.
 -- You can do so yourself, e.g.:
 --
 -- > unpackRaw dir (checkPortability . checkSecurity $ entries)
-unpackRaw :: Exception e => FilePath -> Entries e -> IO ()
-unpackRaw baseDir entries = do
+unpackWith :: Exception e => CheckSecurityCallback -> FilePath -> Entries e -> IO ()
+unpackWith secCB baseDir entries = do
   uEntries <- unpackEntries Nothing Nothing [] entries
   let (hardlinks, symlinks) = partition (\(_, _, x) -> x) uEntries
   -- handle hardlinks first, in case a symlink points to it
@@ -108,6 +115,7 @@ unpackRaw baseDir entries = do
     unpackEntries _ _ _     (Fail err)      = throwIO err
     unpackEntries _ _ links Done            = return links
     unpackEntries mLink mPath links (Next entry es) = do
+      secCB mLink mPath entry
       let path = fromMaybe (entryPath entry) mPath
       case entryContent entry of
         NormalFile file _

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -166,7 +166,7 @@ unpackWith secCB baseDir entries = do
       where
         absPath = baseDir </> path
 
-    saveLink isHardLink (fromFilePathToNative -> path) (fromLinkTargetToNative -> link) links
+    saveLink isHardLink (fromFilePathToNative -> path) (fromLinkTarget -> link) links
       = seq (length path)
           $ seq (length link)
           $ (path, link, isHardLink):links

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -22,7 +22,6 @@ module Codec.Archive.Tar.Unpack (
 import Codec.Archive.Tar.Types
 import Codec.Archive.Tar.Check
 
-import Control.Monad.Catch (MonadThrow, throwM)
 import Data.Bits
          ( testBit )
 import Data.List (partition, nub)
@@ -59,8 +58,6 @@ import Data.Time.Clock.POSIX
 import Control.Exception as Exception
          ( catch )
 
-
-type CheckSecurityCallback = forall m. MonadThrow m => Maybe LinkTarget -> Maybe FilePath -> Entry -> m ()
 
 
 -- | Create local files and directories based on the entries of a tar archive.

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -135,7 +135,7 @@ unpack baseDir entries = do
           unpackEntries Nothing Nothing links es -- ignore other file types
 
 
-    extractFile permissions path content mtime = do
+    extractFile permissions (fromFilePathToNative -> path) content mtime = do
       -- Note that tar archives do not make sure each directory is created
       -- before files they contain, indeed we may have to create several
       -- levels of directory.
@@ -147,16 +147,16 @@ unpack baseDir entries = do
         absDir  = baseDir </> FilePath.Native.takeDirectory path
         absPath = baseDir </> path
 
-    extractDir path mtime = do
+    extractDir (fromFilePathToNative -> path) mtime = do
       createDirectoryIfMissing True absPath
       setModTime absPath mtime
       where
         absPath = baseDir </> path
 
-    saveLink isHardLink path link links = seq (length path)
-                                        $ seq (length link')
-                                        $ (path, link', isHardLink):links
-      where link' = fromLinkTargetToNative link
+    saveLink isHardLink (fromFilePathToNative -> path) (fromLinkTargetToNative -> link) links
+      = seq (length path)
+          $ seq (length link)
+          $ (path, link, isHardLink):links
 
 
     -- for hardlinks, we just copy

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -156,7 +156,7 @@ unpack baseDir entries = do
     saveLink isHardLink path link links = seq (length path)
                                         $ seq (length link')
                                         $ (path, link', isHardLink):links
-      where link' = fromLinkTarget link
+      where link' = fromLinkTargetToNative link
 
 
     -- for hardlinks, we just copy

--- a/Codec/Archive/Tar/Unpack.hs
+++ b/Codec/Archive/Tar/Unpack.hs
@@ -76,21 +76,15 @@ import Control.Exception as Exception
 -- part-way.
 --
 -- On its own, this function only checks for security (using 'checkSecurity').
--- You can do other checks by applying checking functions to the 'Entries' that
--- you pass to this function. For example:
---
--- > unpack dir (checkTarbomb expectedDir entries)
---
--- If you care about the priority of the reported errors then you may want to
--- use 'checkSecurity' before 'checkTarbomb' or other checks.
+-- Use 'unpackWith' if you need more checks.
 --
 unpack :: Exception e => FilePath -> Entries e -> IO ()
 unpack = unpackWith checkSecurity
 
 -- | Like 'unpack', but does not perform any sanity/security checks on the tar entries.
--- You can do so yourself, e.g.:
+-- You can do so yourself, e.g.: @unpackRaw@ 'checkSecurity' @dir@ @entries@.
 --
--- > unpackRaw dir (checkPortability . checkSecurity $ entries)
+-- @since 0.6.0.0
 unpackWith :: Exception e => CheckSecurityCallback -> FilePath -> Entries e -> IO ()
 unpackWith secCB baseDir entries = do
   uEntries <- unpackEntries Nothing Nothing [] entries

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ See also http://pvp.haskell.org/faq
   * Drop deprecated `emptyIndex` and `finaliseIndex`
   * Extend `FileNameError` with `UnsafeLinkTarget` constructor
   * Add `CheckSecurityCallback`, `packWith`, `unpackWith`
-  * Generalize `Entry` and `EntryContent` to `GenEntry` and `GenEntryContent`
+  * Generalize `Entries`, `Entry` and `EntryContent` to `GenEntries`, `GenEntry` and `GenEntryContent`
 
 0.5.1.1 Herbert Valerio Riedel <hvr@gnu.org> August 2019
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@ See also http://pvp.haskell.org/faq
   * Ignore FAT32 errors when setting modification time
   * Switch to trailer parsing mode only after a full block of `NUL`
   * Drop deprecated `emptyIndex` and `finaliseIndex`
+  * Extend `FileNameError` with `UnsafeLinkTarget` constructor
+  * Add `CheckSecurityCallback`, `packWith`, `unpackWith`
 
 0.5.1.1 Herbert Valerio Riedel <hvr@gnu.org> August 2019
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ See also http://pvp.haskell.org/faq
   * Drop deprecated `emptyIndex` and `finaliseIndex`
   * Extend `FileNameError` with `UnsafeLinkTarget` constructor
   * Add `CheckSecurityCallback`, `packWith`, `unpackWith`
+  * Generalize `Entry` and `EntryContent` to `GenEntry` and `GenEntryContent`
 
 0.5.1.1 Herbert Valerio Riedel <hvr@gnu.org> August 2019
 

--- a/htar/htar.hs
+++ b/htar/htar.hs
@@ -113,8 +113,8 @@ detailedInfo entry =
     time = formatEpochTime "%Y-%m-%d %H:%M" (Tar.entryTime entry)
     name = Tar.entryPath entry
     link = case Tar.entryContent entry of
-      Tar.HardLink     l -> " link to " ++ Tar.fromLinkTargetToNative l
-      Tar.SymbolicLink l -> " -> "      ++ Tar.fromLinkTargetToNative l
+      Tar.HardLink     l -> " link to " ++ Tar.fromLinkTarget l
+      Tar.SymbolicLink l -> " -> "      ++ Tar.fromLinkTarget l
       _                  -> ""
 
 justify :: Int -> String -> String -> String

--- a/htar/htar.hs
+++ b/htar/htar.hs
@@ -113,8 +113,8 @@ detailedInfo entry =
     time = formatEpochTime "%Y-%m-%d %H:%M" (Tar.entryTime entry)
     name = Tar.entryPath entry
     link = case Tar.entryContent entry of
-      Tar.HardLink     l -> " link to " ++ Tar.fromLinkTarget l
-      Tar.SymbolicLink l -> " -> "      ++ Tar.fromLinkTarget l
+      Tar.HardLink     l -> " link to " ++ Tar.fromLinkTargetToNative l
+      Tar.SymbolicLink l -> " -> "      ++ Tar.fromLinkTargetToNative l
       _                  -> ""
 
 justify :: Int -> String -> String -> String

--- a/tar.cabal
+++ b/tar.cabal
@@ -137,5 +137,6 @@ benchmark bench
                  array,
                  containers,
                  deepseq,
+                 temporary < 1.4,
                  time,
                  tasty-bench < 0.4

--- a/tar.cabal
+++ b/tar.cabal
@@ -64,6 +64,7 @@ library tar-internal
     Codec.Archive.Tar.Check
     Codec.Archive.Tar.Check.Internal
     Codec.Archive.Tar.Index
+    Codec.Archive.Tar.LongNames
     Codec.Archive.Tar.Types
     Codec.Archive.Tar.Read
     Codec.Archive.Tar.Write

--- a/tar.cabal
+++ b/tar.cabal
@@ -54,6 +54,7 @@ library tar-internal
                  containers >= 0.2  && < 0.8,
                  deepseq    >= 1.1  && < 1.6,
                  directory  >= 1.3.1 && < 1.4,
+                 exceptions,
                  filepath              < 1.5,
                  time                  < 1.13
 

--- a/test/Codec/Archive/Tar/Index/Tests.hs
+++ b/test/Codec/Archive/Tar/Index/Tests.hs
@@ -22,7 +22,7 @@ module Codec.Archive.Tar.Index.Tests (
     prop_finalise_unfinalise,
   ) where
 
-import Codec.Archive.Tar (Entries(..), Entry(..), EntryContent(..))
+import Codec.Archive.Tar (GenEntries(..), Entries, GenEntry, Entry, GenEntryContent(..))
 import Codec.Archive.Tar.Index.Internal (TarIndexEntry(..), TarIndex(..), IndexBuilder, TarEntryOffset(..))
 import qualified Codec.Archive.Tar.Index.Internal as Tar
 import qualified Codec.Archive.Tar.Index.IntTrie as IntTrie

--- a/test/Codec/Archive/Tar/Pack/Tests.hs
+++ b/test/Codec/Archive/Tar/Pack/Tests.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.FileEmbed
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Pack as Pack
-import Codec.Archive.Tar.Types (Entries(..))
+import Codec.Archive.Tar.Types (GenEntries(..), Entries)
 import qualified Codec.Archive.Tar.Unpack as Unpack
 import Control.Exception
 import Data.List.NonEmpty (NonEmpty(..))

--- a/test/Codec/Archive/Tar/Types/Tests.hs
+++ b/test/Codec/Archive/Tar/Types/Tests.hs
@@ -122,7 +122,7 @@ instance Arbitrary LinkTarget where
          . filter (not . null)
          . shrinkList shrinkNothing
          . FilePath.Posix.splitPath
-         . fromLinkTargetToPosixPath
+         . fromLinkTargetToUnix
 
 
 listOf1ToN :: Int -> Gen a -> Gen [a]

--- a/test/Codec/Archive/Tar/Types/Tests.hs
+++ b/test/Codec/Archive/Tar/Types/Tests.hs
@@ -122,7 +122,7 @@ instance Arbitrary LinkTarget where
          . filter (not . null)
          . shrinkList shrinkNothing
          . FilePath.Posix.splitPath
-         . fromLinkTargetToUnix
+         . fromLinkTargetToPosixPath
 
 
 listOf1ToN :: Int -> Gen a -> Gen [a]

--- a/test/Codec/Archive/Tar/Types/Tests.hs
+++ b/test/Codec/Archive/Tar/Types/Tests.hs
@@ -77,7 +77,7 @@ fromTarPathToWindowsPathRef (TarPath namebs prefixbs) = adjustDirectory $
                     = FilePath.Windows.addTrailingPathSeparator
                     | otherwise = id
 
-instance Arbitrary Entry where
+instance (Arbitrary tarPath, Arbitrary linkTarget) => Arbitrary (GenEntry tarPath linkTarget) where
   arbitrary = do
     entryTarPath <- arbitrary
     entryContent <- arbitrary
@@ -135,7 +135,7 @@ listOf0ToN n g = sized $ \sz -> do
     n <- choose (0, min n sz)
     vectorOf n g
 
-instance Arbitrary EntryContent where
+instance Arbitrary linkTarget => Arbitrary (GenEntryContent linkTarget) where
   arbitrary =
     frequency
       [ (16, do bs <- arbitrary;

--- a/test/Codec/Archive/Tar/Unpack/Tests.hs
+++ b/test/Codec/Archive/Tar/Unpack/Tests.hs
@@ -6,7 +6,7 @@ module Codec.Archive.Tar.Unpack.Tests
 
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Types as Tar
-import Codec.Archive.Tar.Types (Entries(..), Entry(..))
+import Codec.Archive.Tar.Types (GenEntries(..), Entries, GenEntry(..))
 import qualified Codec.Archive.Tar.Unpack as Unpack
 import Control.Exception
 import Data.Time.Clock


### PR DESCRIPTION
Key points:
* `..` in a path should be allowed as long as it does not point outside of the archive,
* soft links should be validated as relative paths,
* long names / links should not be exempt from validation.

This is meant to close #27, enabling us to unpack https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x64.tar.xz. 