### PR TITLE
fix package list in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
 resolver: lts-21.21
 
 packages:
+- .
 - htar
-- tar
 
 extra-deps:
 - bzlib-0.5.1.0


### PR DESCRIPTION
When you try to compile the project using Stack, it gives the following error:
```
Error: [S-395]
       Stack looks for packages in the directories configured in the packages and extra-deps fields defined in your stack.yaml.
       The current entry points to /.../tar/tar/ but no such directory could be found. If, alternatively, a
       package in the package index was intended, its name and version must be specified as an extra-dep.
```
This pull request changes the list of packages in `stack.yaml` so that it finds the packages and builds correctly