### PR TITLE
Add more informative “file too long” error message

### DIFF
--- a/Codec/Archive/Tar/Types.hs
+++ b/Codec/Archive/Tar/Types.hs
@@ -454,7 +454,7 @@ toTarPath :: Bool -- ^ Is the path for a directory? This is needed because for
 toTarPath isDir path = case toTarPath' path' of
   FileNameEmpty      -> Left "File name empty"
   FileNameOK tarPath -> Right tarPath
-  FileNameTooLong{}  -> Left "File name too long"
+  FileNameTooLong{}  -> Left $ "File name too long: " ++ path'
   where
     path' = if isDir && not (FilePath.Native.hasTrailingPathSeparator path)
             then path <> [FilePath.Native.pathSeparator]


### PR DESCRIPTION
Closes: haskell/cabal#10615

To `toTarPath`, make it output actual filename apart from "File name too long".